### PR TITLE
#153112491 A user should set timeouts and grace values for days exceeding 30

### DIFF
--- a/hc/api/tests/test_admin.py
+++ b/hc/api/tests/test_admin.py
@@ -10,7 +10,7 @@ class ApiAdminTestCase(BaseTestCase):
         super(ApiAdminTestCase, self).setUp()
         self.check = Check.objects.create(user=self.alice, tags="foo bar")
 
-        ### Set Alice to be staff and superuser and save her :)
+        # Ensure that alice wasn't already superuser
         self.assertFalse(self.alice.is_superuser)
         self.assertFalse(self.alice.is_staff)
 
@@ -28,4 +28,9 @@ class ApiAdminTestCase(BaseTestCase):
         ch = Channel(user=self.alice, kind="pushbullet", value="test-token")
         ch.save()
 
-        ### Assert for the push bullet
+        saved_channel = Channel.objects.get(kind="pushbullet")
+        self.assertIsNot(saved_channel, None)
+        self.assertEqual(saved_channel.kind, "pushbullet")
+        res = self.client.get("/admin/api/channel/")
+
+        self.assertContains(res, "Pushbullet")

--- a/hc/api/tests/test_admin.py
+++ b/hc/api/tests/test_admin.py
@@ -1,6 +1,8 @@
 from hc.api.models import Channel, Check
 from hc.test import BaseTestCase
 
+from django.contrib.auth.models import User
+
 
 class ApiAdminTestCase(BaseTestCase):
 
@@ -9,6 +11,16 @@ class ApiAdminTestCase(BaseTestCase):
         self.check = Check.objects.create(user=self.alice, tags="foo bar")
 
         ### Set Alice to be staff and superuser and save her :)
+        self.assertFalse(self.alice.is_superuser)
+        self.assertFalse(self.alice.is_staff)
+
+        self.alice.is_staff     = True
+        self.alice.is_superuser = True
+        self.alice.save()
+        retrieved_alice         = User.objects.get(username='alice')
+
+        self.assertTrue(retrieved_alice.is_superuser)
+        self.assertTrue(retrieved_alice.is_staff)
 
     def test_it_shows_channel_list_with_pushbullet(self):
         self.client.login(username="alice@example.org", password="password")

--- a/hc/api/tests/test_badge.py
+++ b/hc/api/tests/test_badge.py
@@ -14,6 +14,7 @@ class BadgeTestCase(BaseTestCase):
     def test_it_rejects_bad_signature(self):
         r = self.client.get("/badge/%s/12345678/foo.svg" % self.alice.username)
         ### Assert the expected response status code
+        assert r.status_code == 400
 
     def test_it_returns_svg(self):
         sig = base64_hmac(str(self.alice.username), "foo", settings.SECRET_KEY)
@@ -21,4 +22,6 @@ class BadgeTestCase(BaseTestCase):
         url = "/badge/%s/%s/foo.svg" % (self.alice.username, sig)
 
         r = self.client.get(url)
-        ### Assert that the svg is returned
+        ### Assert that the svg is returned  
+        self.assertContains(r, "<svg")  # because svg's are containde in svg tags
+        self.assertContains(r, "</svg>")

--- a/hc/api/tests/test_check_model.py
+++ b/hc/api/tests/test_check_model.py
@@ -13,6 +13,8 @@ class CheckModelTestCase(TestCase):
         check.tags = " foo  bar "
         self.assertEquals(check.tags_list(), ["foo", "bar"])
         ### Repeat above test for when check is an empty string
+        check.tags = " "
+        self.assertEquals(check.tags_list(), [])
 
     def test_status_works_with_grace_period(self):
         check = Check()
@@ -36,3 +38,6 @@ class CheckModelTestCase(TestCase):
         self.assertFalse(check.in_grace_period())
 
     ### Test that when a new check is created, it is not in the grace period
+        new_check = Check()
+        self.assertFalse(new_check.in_grace_period())
+

--- a/hc/api/tests/test_create_check.py
+++ b/hc/api/tests/test_create_check.py
@@ -35,8 +35,9 @@ class CreateCheckTestCase(BaseTestCase):
         assert "ping_url" in doc
         self.assertEqual(doc["name"], "Foo")
         self.assertEqual(doc["tags"], "bar,baz")
+        self.assertIsNone(doc.get('last_ping'))
+        self.assertEqual(doc.get('n_pings'), 0)
 
-        ### Assert the expected last_ping and n_pings values
 
         self.assertEqual(Check.objects.count(), 1)
         check = Check.objects.get()

--- a/hc/api/tests/test_create_check.py
+++ b/hc/api/tests/test_create_check.py
@@ -69,16 +69,22 @@ class CreateCheckTestCase(BaseTestCase):
         self.assertEqual(r["error"], "could not parse request body")
 
     def test_it_rejects_wrong_api_key(self):
-        self.post({"api_key": "wrong"},
+        res = self.post({"api_key": "wrong"},
                   expected_error="wrong api_key")
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json().get('error'), "wrong api_key")
 
     def test_it_rejects_non_number_timeout(self):
-        self.post({"api_key": "abc", "timeout": "oops"},
+        res = self.post({"api_key": "abc", "timeout": "oops"},
                   expected_error="timeout is not a number")
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json().get('error'), 'timeout is not a number')
 
     def test_it_rejects_non_string_name(self):
-        self.post({"api_key": "abc", "name": False},
+        res = self.post({"api_key": "abc", "name": False},
                   expected_error="name is not a string")
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json().get('error'), 'name is not a string')
 
     ### Test for the assignment of channels
     ### Test for the 'timeout is too small' and 'timeout is too large' errors

--- a/hc/api/tests/test_create_check.py
+++ b/hc/api/tests/test_create_check.py
@@ -49,16 +49,18 @@ class CreateCheckTestCase(BaseTestCase):
     def test_it_accepts_api_key_in_header(self):
         payload = json.dumps({"name": "Foo"})
 
-        ### Make the post request and get the response
-        r = {'status_code': 201} ### This is just a placeholder variable
-
-        self.assertEqual(r['status_code'], 201)
+        res = self.client.post(
+            self.URL,
+            payload,
+            content_type="application/json",
+            HTTP_X_API_KEY='abc'
+        )
+        self.assertEqual(res.status_code, 201)
 
     def test_it_handles_missing_request_body(self):
-        ### Make the post request with a missing body and get the response
-        r = {'status_code': 400, 'error': "wrong api_key"} ### This is just a placeholder variable
-        self.assertEqual(r['status_code'], 400)
-        self.assertEqual(r["error"], "wrong api_key")
+        res = self.post({})
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json().get("error"), "wrong api_key")
 
     def test_it_handles_invalid_json(self):
         ### Make the post request with invalid json data type

--- a/hc/api/tests/test_ensuretriggers.py
+++ b/hc/api/tests/test_ensuretriggers.py
@@ -27,3 +27,4 @@ class EnsureTriggersTestCase(TestCase):
         check.save()
         check.refresh_from_db()
         ### Assert that alert_after is lesser than the check's alert_after 
+        self.assertLess(alert_after, check.alert_after)

--- a/hc/api/tests/test_list_checks.py
+++ b/hc/api/tests/test_list_checks.py
@@ -1,6 +1,7 @@
 import json
 from datetime import timedelta as td
 from django.utils.timezone import now
+from django.conf import settings
 
 from hc.api.models import Check
 from hc.test import BaseTestCase
@@ -34,14 +35,40 @@ class ListChecksTestCase(BaseTestCase):
     def test_it_works(self):
         r = self.get()
         ### Assert the response status code
+        self.assertEqual(r.status_code, 200)
 
         doc = r.json()
         self.assertTrue("checks" in doc)
 
         checks = {check["name"]: check for check in doc["checks"]}
         ### Assert the expected length of checks
+        self.assertEqual(len(checks), 2)
+
         ### Assert the checks Alice 1 and Alice 2's timeout, grace, ping_url, status,
         ### last_ping, n_pings and pause_url
+        """
+        Alice 1
+        """
+        self.assertEqual(checks["Alice 1"]["timeout"], 3600)
+        self.assertEqual(checks["Alice 1"]["grace"], 900)
+        self.assertEqual(checks["Alice 1"]["ping_url"], self.a1.url())
+        self.assertEqual(checks["Alice 1"]["status"], "new")
+        self.assertEqual(checks["Alice 1"]["last_ping"], self.a1.last_ping.isoformat())
+        self.assertEqual(checks["Alice 1"]["n_pings"], 1)
+        update_url = settings.SITE_ROOT + "/api/v1/checks/%s" % self.a1.code
+        pause_url = update_url + "/pause"
+        self.assertEqual(checks["Alice 1"]["pause_url"], pause_url)
+        """
+        Alice 2
+        """
+        self.assertEqual(checks["Alice 2"]["timeout"], 86400)
+        self.assertEqual(checks["Alice 2"]["grace"], 3600)
+        self.assertEqual(checks["Alice 2"]["ping_url"], self.a2.url())
+        self.assertEqual(checks["Alice 2"]["status"], "up")
+        self.assertEqual(checks["Alice 2"]["last_ping"], self.a2.last_ping.isoformat())
+        update_url = settings.SITE_ROOT + "/api/v1/checks/%s" % self.a2.code
+        pause_url = update_url + "/pause"
+        self.assertEqual(checks["Alice 2"]["pause_url"], pause_url)      
 
     def test_it_shows_only_users_checks(self):
         bobs_check = Check(user=self.bob, name="Bob 1")
@@ -54,3 +81,11 @@ class ListChecksTestCase(BaseTestCase):
             self.assertNotEqual(check["name"], "Bob 1")
 
     ### Test that it accepts an api_key in the request
+        # put api key in payload variable
+        payload = json.dumps({"api_key": "abc"})
+        # add payload to the request.
+        # without api_key in the payload or wrong value of api_key, this request fails
+        response = self.client.generic("GET", "/api/v1/checks/", payload,
+                                content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        

--- a/hc/api/tests/test_sendalerts.py
+++ b/hc/api/tests/test_sendalerts.py
@@ -20,8 +20,10 @@ class SendAlertsTestCase(BaseTestCase):
             check.status = "up"
             check.save()
 
+        ### Assert when Command's handle many that when handle_many should return True
         result = Command().handle_many()
         assert result, "handle_many should return True"
+        self.assertTrue(result, True)
 
         handled_names = []
         for args, kwargs in mock.call_args_list:
@@ -38,5 +40,4 @@ class SendAlertsTestCase(BaseTestCase):
 
         # Expect no exceptions--
         Command().handle_one(check)
-
-    ### Assert when Command's handle many that when handle_many should return True
+        


### PR DESCRIPTION
**What does this PR do?**
Enable a user to configure checks longer than 30 days and that is up to 60 days.

**Description of Task to be completed?**
We have a slider currently(UI) that can allow a user to extend it to 30 days and that means that our user is limited to only 30 days. Our task was to enhance both the UI and the backend that a user can extend the slider to 60 days and both the grace and period time is saved.

**How should this be manually tested?**
- Setup the app locally using our README.md
- Use `python manage.py runserver` to run the server and log in using your superuser credentials.
- Create a check and once you click the period/grace section, you'll be able to extend both the grace/period time to 60 days.

**What are the relevant pivotal tracker stories?**
#153112491

**Screenshots**
<img width="695" alt="screen shot 2017-12-11 at 10 57 27" src="https://user-images.githubusercontent.com/19430799/33820818-450f3cd6-de62-11e7-8726-8eeb0d2eea3b.png">
