### PR TITLE
#153112490 User's dashboard to view failed jobs

### DIFF
--- a/hc/front/urls.py
+++ b/hc/front/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     url(r'^$', views.index, name="hc-index"),
     url(r'^checks/$', views.my_checks, name="hc-checks"),
     url(r'^checks/add/$', views.add_check, name="hc-add-check"),
+    url(r'^checks/failed-jobs/$', views.failed_jobs, name="hc-failed-jobs"),
     url(r'^checks/([\w-]+)/', include(check_urls)),
     url(r'^integrations/', include(channel_urls)),
 

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -255,8 +255,6 @@ def log(request, code):
 def failed_jobs(request):
     """Fetch failed jobs"""
     get_checks = Check.objects.filter(user=request.team.user).order_by("created")
-    print(get_checks)
-    
     all_checks = list(get_checks)
     
     counter = Counter()
@@ -267,7 +265,6 @@ def failed_jobs(request):
         if status == "down":
             # Add a down check to failed check list to be rendered
             failed_checks.append(check)
-        print(type(check))
         
         for tag in check.tags_list():
             if tag == "":

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -251,6 +251,16 @@ def log(request, code):
 
 
 @login_required
+def failed_jobs(request):
+    templatename = 'front/failed_jobs.html'
+    failed_jobs_qs = []
+    context = {
+        'failed_jobs': failed_jobs_qs
+    }
+    return render(request, templatename, context)
+
+
+@login_required
 def channels(request):
     if request.method == "POST":
         code = request.POST["channel"]

--- a/templates/base.html
+++ b/templates/base.html
@@ -124,6 +124,8 @@
 
                         <li><a href="{% url 'hc-profile' %}">Account Settings</a></li>
                         <li role="separator" class="divider"></li>
+                        <li><a href="{% url 'hc-failed-jobs' %}">Failed Jobs</a></li>
+                        <li role="separator" class="divider"></li>
 
                         {% for team in request.teams %}
                         <li class="dropdown-header">{{ team }}</li>

--- a/templates/front/failed_jobs.html
+++ b/templates/front/failed_jobs.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% load compress staticfiles %}
+
+{% block title %}My Checks - healthchecks.io{% endblock %}
+
+
+{% block content %}
+<div class="row">
+    <div class="col-sm-12">
+        <h1>
+        {% if request.team == request.user.profile %}
+            My Failed Jobs
+        {% else %}
+            {{ request.team.team_name }}
+        {% endif %}
+        </h1>
+    </div>
+    {% if tags %}
+    <div id="my-checks-tags" class="col-sm-12">
+        {% for tag, count in tags %}
+            {% if tag in down_tags %}
+                <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button>
+            {% elif tag in grace_tags %}
+                <button class="btn btn-warning btn-xs" data-toggle="button">{{ tag }}</button>
+            {% else %}
+                <button class="btn btn-default btn-xs" data-toggle="button">{{ tag }}</button>
+            {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+
+</div>
+<div class="row">
+    <div class="col-sm-12">
+
+
+    {% if failed_jobs %}
+        {% comment %} {% include "front/my_checks_mobile.html" %} {% endcomment %}
+        {% include "front/my_failed_jobs.html" %}
+    {% else %}
+    <div class="alert alert-info">You don't have any failed jobs yet.</div>
+    {% endif %}
+    </div>
+</div>
+
+{% endblock %}
+
+{% block scripts %}
+{% compress js %}
+<script src="{% static 'js/jquery-2.1.4.min.js' %}"></script>
+<script src="{% static 'js/bootstrap.min.js' %}"></script>
+<script src="https://gitcdn.github.io/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js"></script>
+<script src="{% static 'js/nouislider.min.js' %}"></script>
+<script src="{% static 'js/clipboard.min.js' %}"></script>
+<script src="{% static 'js/checks.js' %}"></script>
+{% endcompress %}
+{% endblock %}

--- a/templates/front/failed_jobs.html
+++ b/templates/front/failed_jobs.html
@@ -32,9 +32,7 @@
 </div>
 <div class="row">
     <div class="col-sm-12">
-
-
-    {% if failed_jobs %}
+    {% if failed_checks %}
         {% comment %} {% include "front/my_checks_mobile.html" %} {% endcomment %}
         {% include "front/my_failed_jobs.html" %}
     {% else %}

--- a/templates/front/my_failed_jobs.html
+++ b/templates/front/my_failed_jobs.html
@@ -1,0 +1,119 @@
+{% load hc_extras humanize %}
+<table id="checks-table" class="table hidden-xs">
+    <tr>
+        <th></th>
+        <th class="th-name">Name</th>
+        <th>Ping URL</th>
+        <th class="th-period">
+            Period <br />
+            <span class="checks-subline">Grace</span>
+        </th>
+        <th>Last Ping</th>
+        <th></th>
+    </tr>
+    {% for check in failed_jobs %}
+    <tr class="checks-row">
+        <td class="indicator-cell">
+            {% if check.get_status == "new" %}
+                <span class="status icon-up new"
+                    data-toggle="tooltip" title="New. Has never received a ping."></span>
+            {% elif check.get_status == "paused" %}
+                <span class="status icon-paused"
+                    data-toggle="tooltip" title="Monitoring paused. Ping to resume."></span>
+            {% elif check.in_grace_period %}
+                <span class="status icon-grace"></span>
+            {% elif check.get_status == "up" %}
+                <span class="status icon-up"></span>
+            {% elif check.get_status == "down" %}
+                <span class="status icon-down"></span>
+            {% endif %}
+        </td>
+        <td class="name-cell">
+            <div data-name="{{ check.name }}"
+                    data-tags="{{ check.tags }}"
+                    data-url="{% url 'hc-update-name' check.code %}"
+                    class="my-checks-name {% if not check.name %}unnamed{% endif %}">
+                <div>{{ check.name|default:"unnamed" }}</div>
+                {% for tag in check.tags_list %}
+                <span class="label label-tag">{{ tag }}</span>
+                {% endfor %}
+            </div>
+        </td>
+        <td class="url-cell">
+            <span class="my-checks-url">
+                <span class="base">{{ ping_endpoint }}</span>{{ check.code }}
+            </span>
+            <button
+                class="copy-link hidden-sm"
+                data-clipboard-text="{{ check.url }}">
+                copy
+            </button>
+        </td>
+        <td class="timeout-cell">
+            <span
+                data-url="{% url 'hc-update-timeout' check.code %}"
+                data-timeout="{{ check.timeout.total_seconds }}"
+                data-grace="{{ check.grace.total_seconds }}"
+                class="timeout-grace">
+                {{ check.timeout|hc_duration }}
+                <br />
+                <span class="checks-subline">
+                {{ check.grace|hc_duration }}
+                </span>
+            </span>
+        </td>
+        <td>
+        {% if check.last_ping %}
+            <span
+                data-toggle="tooltip"
+                title="{{ check.last_ping|date:'N j, Y, P e' }}">
+                {{ check.last_ping|naturaltime }}
+            </span>
+        {% else %}
+            Never
+        {% endif %}
+        </td>
+
+        <td>
+            <div class="check-menu dropdown">
+                <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                <span class="icon-settings" aria-hidden="true"></span>
+                </button>
+                <ul class="dropdown-menu">
+                    <li {% if check.status == "new" or check.status == "paused" %}class="disabled"{% endif %}>
+                        <a class="pause-check"
+                           href="#"
+                           data-url="{% url 'hc-pause' check.code %}">
+                           Pause Monitoring
+                        </a>
+                    </li>
+                    <li role="separator" class="divider"></li>
+                    <li>
+                        <a href="{% url 'hc-log' check.code %}">
+                            Log
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            href="#"
+                            class="usage-examples"
+                            data-url="{{ check.url }}"
+                            data-email="{{ check.email }}">
+                            Usage Examples
+                        </a>
+                    </li>
+                    <li role="separator" class="divider"></li>
+                    <li>
+                        <a href="#" class="check-menu-remove"
+                            data-name="{{ check.name_then_code }}"
+                            data-url="{% url 'hc-remove-check' check.code %}">
+                            Remove
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </td>
+    </tr>
+    {% endfor %}
+
+</table>

--- a/templates/front/my_failed_jobs.html
+++ b/templates/front/my_failed_jobs.html
@@ -3,7 +3,7 @@
     <tr>
         <th></th>
         <th class="th-name">Name</th>
-        <th>Ping URL</th>
+        <th>Ping UL</th>
         <th class="th-period">
             Period <br />
             <span class="checks-subline">Grace</span>
@@ -11,21 +11,13 @@
         <th>Last Ping</th>
         <th></th>
     </tr>
-    {% for check in failed_jobs %}
+    {% for check in failed_checks %}
     <tr class="checks-row">
         <td class="indicator-cell">
-            {% if check.get_status == "new" %}
-                <span class="status icon-up new"
-                    data-toggle="tooltip" title="New. Has never received a ping."></span>
-            {% elif check.get_status == "paused" %}
-                <span class="status icon-paused"
-                    data-toggle="tooltip" title="Monitoring paused. Ping to resume."></span>
-            {% elif check.in_grace_period %}
-                <span class="status icon-grace"></span>
-            {% elif check.get_status == "up" %}
-                <span class="status icon-up"></span>
-            {% elif check.get_status == "down" %}
+            {% if check.get_status == "down" %}
                 <span class="status icon-down"></span>
+            {% else %}
+                <span class="status icon-missing"></span>
             {% endif %}
         </td>
         <td class="name-cell">


### PR DESCRIPTION
**What does this PR do?**

In this PR we created a dashboard for a user to view failed jobs

**Description of Task to be completed?**

We provided a new link that directs a user to a dashboard. The dashboard shows him all the checks that went down

**How should this be manually tested?**

- Follow the README.md to setup the application then access the app through the url prompted.

- After creating an account and a check, you should be able to navigate in the right corner _dropdown menu_ and see _failed jobs_. *Note:* Check [Screenshot](https://user-images.githubusercontent.com/19430799/34664462-1282325c-f46d-11e7-9b43-6cbe28c2e889.png)

**What are the relevant pivotal tracker stories?**

#153112490

**Screenshot**

<img width="1411" alt="screen shot 2018-01-08 at 12 11 13" src="https://user-images.githubusercontent.com/19430799/34664462-1282325c-f46d-11e7-9b43-6cbe28c2e889.png">