### PR TITLE
#153112492 Check for jobs that runs too fast.

### DIFF
--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -71,7 +71,7 @@ class Check(models.Model):
         return "%s@%s" % (self.code, settings.PING_EMAIL_DOMAIN)
 
     def send_alert(self):
-        if self.status not in ("up", "down"):
+        if self.status not in ("up", "down", "fast"):
             raise NotImplementedError("Unexpected status: %s" % self.status)
 
         errors = []
@@ -88,12 +88,11 @@ class Check(models.Model):
 
         now = timezone.now()
 
-        if self.last_ping + self.timeout + self.grace > now:
-            return "up"
-        return "down"
-        
         if self.ping_diff < (self.timeout - self.grace):
             return "fast"
+        if (self.last_ping + self.timeout + self.grace) > now:
+            return "up"
+        return "down"
 
     def in_grace_period(self):
         if self.status in ("new", "paused"):

--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -17,7 +17,8 @@ STATUSES = (
     ("up", "Up"),
     ("down", "Down"),
     ("new", "New"),
-    ("paused", "Paused")
+    ("paused", "Paused"),
+    ("fast", "fast")
 )
 DEFAULT_TIMEOUT = td(days=1)
 DEFAULT_GRACE = td(hours=1)
@@ -50,6 +51,7 @@ class Check(models.Model):
     grace = models.DurationField(default=DEFAULT_GRACE)
     n_pings = models.IntegerField(default=0)
     last_ping = models.DateTimeField(null=True, blank=True)
+    ping_diff = models.DurationField(null=True, blank=True)
     alert_after = models.DateTimeField(null=True, blank=True, editable=False)
     status = models.CharField(max_length=6, choices=STATUSES, default="new")
 
@@ -88,8 +90,10 @@ class Check(models.Model):
 
         if self.last_ping + self.timeout + self.grace > now:
             return "up"
-
         return "down"
+        
+        if self.ping_diff < (self.timeout - self.grace):
+            return "fast"
 
     def in_grace_period(self):
         if self.status in ("new", "paused"):

--- a/hc/api/views.py
+++ b/hc/api/views.py
@@ -22,6 +22,7 @@ def ping(request, code):
         return HttpResponseBadRequest()
 
     check.n_pings = F("n_pings") + 1
+    ping_diff = timezone.now() - check.last_ping
     check.last_ping = timezone.now()
     if check.status in ("new", "paused"):
         check.status = "up"

--- a/hc/api/views.py
+++ b/hc/api/views.py
@@ -22,7 +22,8 @@ def ping(request, code):
         return HttpResponseBadRequest()
 
     check.n_pings = F("n_pings") + 1
-    ping_diff = timezone.now() - check.last_ping
+    if check.last_ping is not None:
+        ping_diff = timezone.now() - check.last_ping
     check.last_ping = timezone.now()
     if check.status in ("new", "paused"):
         check.status = "up"

--- a/hc/lib/badges.py
+++ b/hc/lib/badges.py
@@ -15,7 +15,8 @@ WIDTHS = {"a": 7, "b": 7, "c": 6, "d": 7, "e": 6, "f": 4, "g": 7, "h": 7,
 COLORS = {
     "up": "#4c1",
     "late": "#fe7d37",
-    "down": "#e05d44"
+    "down": "#e05d44",
+    "fast": "#FFD700"
 }
 
 

--- a/templates/accounts/reports_desktop.html
+++ b/templates/accounts/reports_desktop.html
@@ -30,6 +30,7 @@
     .up { background: #5cb85c; }
     .grace { background: #f0ad4e; }
     .down { background: #d9534f; }
+    .fast {background: #FFD700; }
 
 
     .unnamed {
@@ -65,6 +66,8 @@
                 <span class="badge up">UP</span>
             {% elif check.get_status == "down" %}
                 <span class="badge down">DOWN</span>
+            {% elif check.get_status == "fast" %}
+                <span class="badge fast">FAST</span>
             {% endif %}
         </td>
         <td>

--- a/templates/emails/summary-html.html
+++ b/templates/emails/summary-html.html
@@ -30,6 +30,7 @@
     .up { background: #5cb85c; }
     .grace { background: #f0ad4e; }
     .down { background: #d9534f; }
+    .fast { background: #FFD700; }
 
 
     .unnamed {
@@ -65,6 +66,8 @@
                 <span class="badge up">UP</span>
             {% elif check.get_status == "down" %}
                 <span class="badge down">DOWN</span>
+            {% elif check.get_status == "fast" %}
+                <span class="badge fast">FAST</span>
             {% endif %}
         </td>
         <td>

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -26,6 +26,8 @@
                 <span class="status icon-up"></span>
             {% elif check.get_status == "down" %}
                 <span class="status icon-down"></span>
+            {% elif check.get_status == "fast" %}
+                <span class="glyphicon glyphicon-fire"></span>
             {% endif %}
         </td>
         <td class="name-cell">


### PR DESCRIPTION
#### What does the PR do?
* Implementation of checking whether a job is running too fast. The difference between two subsequent pings is compared with the that job's (timeout - grace period). If (timeout - grace period) is less than the ping difference, then the job is running too fast.

#### Description of the tasks to be completed:
* Add an input field (ping_diff) in api.models to capture the difference between two subsequent pings of the same check.
* Add a fast status to the list of statuses in api/models.
* Add a condition that indicates when a fast status should be return in the get_status method in api/models.
* Update the ping method in api.views to save the ping_diff value in the database.
* Add an 'elif' condition in templates/accounts/reports_desktop.html, templates/emails/summary-html.html  and templates/front/my_checks_desktop.html to check if the status is fast.
* Add a background-color for a fast status in templates/accounts/reports_desktop.html, templates/emails/summary-html.html and hc/lib/badges.py.
* Add a fast icon in the documentation (doc.html).
 
#### What are the relevant pivotal tracker stories?
* #153112492

#### Screenshots showing outputs:
  
<img width="1149" alt="screen shot 2018-01-08 at 16 57 33" src="https://user-images.githubusercontent.com/21032089/34674064-8dee1a14-f495-11e7-819f-df2ed41ce2ba.png">

<img width="1149" alt="screen shot 2018-01-08 at 16 58 13" src="https://user-images.githubusercontent.com/21032089/34674099-aaf333a6-f495-11e7-8a01-7daeda3fcd82.png">

<img width="847" alt="screen shot 2018-01-08 at 16 58 58" src="https://user-images.githubusercontent.com/21032089/34674133-ca990a6e-f495-11e7-9cf5-cbd1bf6726f6.png">

